### PR TITLE
Default port option is 4723 not 4732

### DIFF
--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -105,7 +105,7 @@ const config = (() => {
         options.devMode = true;
         console.log(`Option attachToDebug is set to true. Option --devMode is set true as well !`)
         if (!options.port) {
-            logWarn(`Default appium server port 4732!`);
+            logWarn(`Default appium server port 4723`;
             logWarn(`In order to change it use --port option!`);
         }
     }


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
Default port suggestion is incorrect. It shows 4732 when it should be 4723.

## What is the new behavior?
Changed the suggestion to be 4723.
